### PR TITLE
merge v1.7.1-beta6

### DIFF
--- a/src/Bakabase.InsideWorld.App.Core/ClientApp/src/components/PathSegmentsConfiguration/SegmentMatcherConfiguration/index.scss
+++ b/src/Bakabase.InsideWorld.App.Core/ClientApp/src/components/PathSegmentsConfiguration/SegmentMatcherConfiguration/index.scss
@@ -19,6 +19,9 @@
 
     .title {
       margin-bottom: 20px;
+      display: flex;
+      align-items: center;
+      gap: 5px;
 
       .next-radio-wrapper {
         .next-radio-label {

--- a/src/Bakabase.InsideWorld.App.Core/ClientApp/src/components/PathSegmentsConfiguration/SegmentMatcherConfiguration/index.tsx
+++ b/src/Bakabase.InsideWorld.App.Core/ClientApp/src/components/PathSegmentsConfiguration/SegmentMatcherConfiguration/index.tsx
@@ -1,4 +1,4 @@
-import { Button, Input, Radio, Tag } from '@alifd/next';
+import { Balloon, Button, Input, Radio, Tag } from '@alifd/next';
 import React, { useState } from 'react';
 import './index.scss';
 import { useUpdateEffect } from 'react-use';
@@ -8,6 +8,7 @@ import type { IMatcherValue } from '@/components/PathSegmentsConfiguration/model
 import { ResourceMatcherValueType } from '@/components/PathSegmentsConfiguration/models/MatcherValue';
 import { execAll } from '@/components/utils';
 import { getResultFromExecAll } from '@/components/PathSegmentsConfiguration/utils';
+import CustomIcon from '@/components/CustomIcon';
 
 interface IValue {
   layer?: number;
@@ -165,9 +166,20 @@ const SegmentMatcherConfiguration = (props: ISegmentMatcherConfiguration) => {
               label={t('Set by {{thing}}', { thing: t('regex') })}
               checked={mode == 'regex'}
             />
-            <div className="tip">
+            <Balloon.Tooltip
+              trigger={(
+                <CustomIcon type={'question-circle'} />
+              )}
+              triggerType={'hover'}
+              align={'t'}
+              v2
+            >
+              {t('/ is the directory separator always, not \\')}
+              <br />
+              <br />
               {t('The whole matched text will be ignored if capturing groups are used')}
-            </div>
+              {t('You should not use capturing groups on Resource property due to partial path is not available to match a file system entry')}
+            </Balloon.Tooltip>
           </div>
           <div className="value">
             <div className="text">

--- a/src/Bakabase.InsideWorld.App.Core/ClientApp/src/components/PathSegmentsConfiguration/index.tsx
+++ b/src/Bakabase.InsideWorld.App.Core/ClientApp/src/components/PathSegmentsConfiguration/index.tsx
@@ -96,7 +96,7 @@ const PathSegmentsConfiguration = React.forwardRef((props: IPathSegmentsConfigur
         const rootSegmentIndex = rootMatch?.index ?? -1;
 
         const resourceSegmentIndex = PathSegmentMatcher
-          .match(segments, resourceMatcherValue, rootSegmentIndex, undefined)?.index ?? -1;
+          .match(segments, resourceMatcherValue, rootSegmentIndex, segments.length)?.index ?? -1;
         if (resourceSegmentIndex > -1) {
           const resourceMatcherMatchesLastLayer = resourceSegmentIndex == segments.length - 1;
           if (resourceMatcherMatchesLastLayer != resourceMatcherMatchesLastLayerRef.current) {
@@ -711,6 +711,13 @@ const PathSegmentsConfiguration = React.forwardRef((props: IPathSegmentsConfigur
                   setFileResourceExtensions(list);
                   if (currentFileExt) {
                     setFileResourceExtensionCandidates([currentFileExt]);
+
+                    // we should change the value of resource matcher to file-extension-based regex immediately when user click this button
+                    const newRegex = buildLayerBasedPathRegexString(segments.length - rootSegmentIndex - 1, [currentFileExt]);
+                    value[ResourceProperty.Resource] = [
+                      MatcherValue.Regex(newRegex),
+                    ];
+                    setValue({ ...value });
                   }
                 }
               })
@@ -765,7 +772,7 @@ const PathSegmentsConfiguration = React.forwardRef((props: IPathSegmentsConfigur
                         const idx = candidates.indexOf(e.ext);
 
                         const apply = candidates => {
-                          const newRegex = buildLayerBasedPathRegexString(segments.length, candidates);
+                          const newRegex = buildLayerBasedPathRegexString(segments.length - rootSegmentIndex - 1, candidates);
                           value[ResourceProperty.Resource] = [
                             MatcherValue.Regex(newRegex),
                           ];

--- a/src/Bakabase.InsideWorld.App.Core/ClientApp/src/components/utils.tsx
+++ b/src/Bakabase.InsideWorld.App.Core/ClientApp/src/components/utils.tsx
@@ -260,7 +260,7 @@ export function buildLayerBasedPathRegexString(layer, extensions?: string[]): st
     } else {
       if (extensions) {
         if (extensions.length > 0) {
-          reg += `\\.(${extensions.map(e => e.replace(/^\./, '')
+          reg += `\\.(?:${extensions.map(e => e.replace(/^\./, '')
             .replaceAll('.', '\\.'))
             .join('|')})`;
           break;

--- a/src/Bakabase.InsideWorld.App.Core/ClientApp/src/localization/cn.json
+++ b/src/Bakabase.InsideWorld.App.Core/ClientApp/src/localization/cn.json
@@ -864,5 +864,7 @@
   "Exit behavior": "退出交互",
   "Minimize": "最小化",
   "Exit": "退出",
-  "Prompt": "提示"
+  "Prompt": "提示",
+  "/ is the directory separator always, not \\": "除非特别说明，一般使用/作为目录路径分隔符，而不是\\",
+  "You should not use capturing groups on Resource property due to partial path is not available to match a file system entry": "您不应该在*资源*属性中使用捕获组，因为不完整的匹配结果将无法定位到文件系统中的文件(夹)"
 }

--- a/src/Bakabase.InsideWorld.App.Wpf/Bakabase.InsideWorld.App.Wpf.csproj
+++ b/src/Bakabase.InsideWorld.App.Wpf/Bakabase.InsideWorld.App.Wpf.csproj
@@ -6,7 +6,7 @@
 	  <Nullable>enable</Nullable>
 	  <UseWPF>true</UseWPF>
 	  <ImplicitUsings>enable</ImplicitUsings>
-	  <Version>1.7.1-beta5</Version>
+	  <Version>1.7.1-beta6</Version>
 	  <SpaRoot>ClientApp\</SpaRoot>
 	  <ApplicationIcon>Assets/favicon.ico</ApplicationIcon>
 	  <InsideWorldCoreAssembly>Bakabase.InsideWorld.App.Core</InsideWorldCoreAssembly>

--- a/src/Bakabase.InsideWorld.Business/Services/MediaLibraryService.cs
+++ b/src/Bakabase.InsideWorld.Business/Services/MediaLibraryService.cs
@@ -168,7 +168,7 @@ namespace Bakabase.InsideWorld.Business.Services
                     case ResourceProperty.CustomProperty:
                     {
                         var matchResult =
-                            ResourcePropertyMatcher.Match(segments, s, rootPathSegments.Length - 1, segments.Length - 1);
+                            ResourcePropertyMatcher.Match(segments, s, rootPathSegments.Length - 1, segments.Length);
 
                         
                         if (matchResult != null)
@@ -853,8 +853,8 @@ namespace Bakabase.InsideWorld.Business.Services
                 {
                     var segments = f.SplitPathIntoSegments();
                     var resourceMatchValue = ResourcePropertyMatcher.Match(segments, resourceMatcherValue,
-                        rootSegments.Length - 1, segments.Length - 1);
-                    if (resourceMatchValue is not {Type: MatchResultType.Layer} || resourceMatchValue.Index < segments.Length - 1)
+                        rootSegments.Length - 1, segments.Length);
+                    if (resourceMatchValue is not {Type: MatchResultType.Layer} || resourceMatchValue.Index < rootSegments.Length)
                     {
                         continue;
                     }
@@ -871,18 +871,12 @@ namespace Bakabase.InsideWorld.Business.Services
                         RelativePath = relativePath
                     };
 
-                    if (f.Contains("防嵌套"))
-                    {
-
-                    }
-
                     var otherMatchers = pc.RpmValues!.Where(a =>
                         a.Property != ResourceProperty.Resource && a.Property != ResourceProperty.RootPath).ToList();
 
                     foreach (var m in otherMatchers)
                     {
-                        var result = ResourcePropertyMatcher.Match(segments, m, rootSegments.Length - 1,
-                            segments.Length - 1);
+                        var result = ResourcePropertyMatcher.Match(segments, m, rootSegments.Length - 1, segments.Length);
                         if (result != null)
                         {
                             switch (result.Type)


### PR DESCRIPTION
fix #423;
add tips for regex matcher;
fix: interactive button for 'matching by file extension' is not showing after the first time opening PathSegmentMatcher if Resource matcher matches a file;